### PR TITLE
Adapt to upstream changes in the Plutus repository.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ WORKDIR /opt/plutus/plutus-playground-client
 # TODO this should not be done on build, create scripts to launch the processes
 RUN sed -i -e 's/localhost:8080/server:8080/g' default.nix 
 RUN sed -i -e 's/localhost:8080/server:8080/g' webpack.config.js
-RUN sed -i -e 's/--progress/--progress --host=0.0.0.0/g' package.json
+RUN sed -i -e 's/webpack-dev-server --progress/webpack-dev-server --host=0.0.0.0 --progress/g' package.json
+RUN sed -i -e 's/webpack-cli serve/webpack-cli serve --host=0.0.0.0/g' package.json
 
 WORKDIR /opt/plutus
 RUN nix-shell --run "cd plutus-playground-client && npm install && plutus-playground-generate-purs && npm run purs:compile && npm run webpack"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,10 @@ RUN echo "trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdj
 RUN apk add git
 
 WORKDIR /opt
-RUN git clone https://github.com/input-output-hk/plutus
-# Just to change something so the fetch and rebase runs
-ENV WEEK=06 
-RUN cd plutus && git fetch && git rebase
-RUN cd plutus && git checkout ae35c4b8fe66dd626679bd2951bd72190e09a123
+ARG PLUTUS_GIT_COMMIT=ae35c4b8fe66dd626679bd2951bd72190e09a123
+RUN git clone https://github.com/input-output-hk/plutus /opt/plutus && \
+	cd /opt/plutus && \
+	git checkout ${PLUTUS_GIT_COMMIT}
 
 WORKDIR /opt/plutus
 


### PR DESCRIPTION
The sed-based patch no longer works since [this upstream commit](https://github.com/input-output-hk/plutus/commit/d9a840894576a9bec3274c8b0d349a93f6f86ac3).
Note that the first line works for older commits and the second for newer commits. So one might drop the first line going forward.